### PR TITLE
about format: User display names and avatars

### DIFF
--- a/formats/about/SPEC_1.0.md
+++ b/formats/about/SPEC_1.0.md
@@ -5,25 +5,34 @@
 	<dt>Version</dt><dd>1.0</dd>
 </dl>
 
-This is an application format for describing personal information (e.g. display names, avatars, bios) associated with particular author keypairs.
+This is an application format for describing personal information (e.g. display
+names, avatars, bios) associated with particular author keypairs.
 
 ## Keypair association
 
-Personal information should only be publishable and modifiable by the holder of a specific keypair. 
+Personal information should only be publishable and modifiable by the holder of
+a specific keypair.
 
 Therefore, each documents following this format is prefixed with the following:
 
 `/about/1.0/~{KEYPAIR_ADDRESS}`
 
-Where `KEYPAIR_ADDRESS` is the full public address of the keypair associated with this document, e.g. `@suzy.bo5sotcncvkr7p4c3lnexxpb4hjqi5tcxcov5b4irbnnz2teoifua`.
+Where `KEYPAIR_ADDRESS` is the full public address of the keypair associated
+with this document, e.g.
+`@suzy.bo5sotcncvkr7p4c3lnexxpb4hjqi5tcxcov5b4irbnnz2teoifua`.
 
-The presence of an author keypair prefixed with a tilde in a path invokes path ownership, and only this keypair will be able to write to these paths.
+The presence of an author keypair prefixed with a tilde in a path invokes path
+ownership, and only this keypair will be able to write to these paths.
 
 ## Display names
 
-Author keypairs begin with a shortname to make the keypair easier to identify, e.g. `suzy`. These shortnames cannot be changed and are always four characters long. This makes them unsuitable for most names and the fluctuating nature of identity.
+Author keypairs begin with a shortname to make the keypair easier to identify,
+e.g. `suzy`. These shortnames cannot be changed and are always four characters
+long. This makes them unsuitable for most names and the fluctuating nature of
+identity.
 
-Therefore it is desirable to have a free-form display name which can be changed at any time, and which can differ between each share.
+Therefore it is desirable to have a free-form display name which can be changed
+at any time, and which can differ between each share.
 
 ### Display name document path
 
@@ -35,7 +44,8 @@ The path format of a display name document is:
 
 ### Display name document fields
 
-The `text` property of the document is the display name the keypair's owner wishes to use. It can be any UTF-8 string.
+The `text` property of the document is the display name the keypair's owner
+wishes to use. It can be any UTF-8 string.
 
 ## Avatars
 
@@ -49,13 +59,16 @@ The path format of a display name document is:
 `/about/1.0/~{KEYPAIR_ADDRESS}`/avatar.{IMAGE_EXTENSION}
 ```
 
-where `IMAGE_EXTENSION` is either `gif`, `jpg`, or `png`, corresponding to the format of the data used with this document's attachment.
+where `IMAGE_EXTENSION` MUST be the file extension of an image format (e.g.
+`gif`, `jpg`, `png`) which allows clients to know how to interpret the
+attachment data for this document.
 
 ### Avatar document fields
 
-- The `text` property of the document MUST be a textual description of the avatar image's contents, for use with screenreaders etc.
+- The `text` property of the document MUST be a textual description of the
+  avatar image's contents, for use with screenreaders etc.
 - The attachment of the document MUST be an image file.
-	- The file size of the image MUST be less than or equal to 500,000 bytes.
-	- The dimensions of the image MUST NOT exceed 512 pixels on either side.
-	- The image SHOULD have a 1:1 aspect ratio.
-
+  - The image SHOULD have a 1:1 aspect ratio.
+    - The image SHOULD NOT be larger than 1,000,000 bytes. These images may be
+      presented in interfaces where they are rendered alongside many other
+      avatars, and which may impact the performance of rendering.

--- a/formats/about/SPEC_1.0.md
+++ b/formats/about/SPEC_1.0.md
@@ -75,12 +75,12 @@ attachment data for this document.
 
 ## Status
 
-A short status message (e.g. "Away from keyboard") can optionally be associated
-with an author keypair.
+A status message (e.g. "Away from keyboard") can optionally be associated with
+an author keypair.
 
 ## Status document path
 
-The path format of a display name document is:
+The path format of a status document is:
 
 ```
 `/about/1.0/~{KEYPAIR_ADDRESS}`/status
@@ -89,4 +89,23 @@ The path format of a display name document is:
 ## Status document fields
 
 The `text` property of the document is the status message the author wishes to
-associate with their keypair. It can be any UTF-8 string.
+associate with their keypair. It can be any UTF-8 string. The status message
+SHOULD be equal or less to 128 characters.
+
+## Biography
+
+Some biographical information can optionally be associated with an author
+keypair.
+
+## Biography document path
+
+The path format of a biography document is:
+
+```
+`/about/1.0/~{KEYPAIR_ADDRESS}`/bio
+```
+
+## Status document fields
+
+The `text` property of the document is the biography message the author wishes
+to associate with their keypair. It can be any UTF-8 string of any length.

--- a/formats/about/SPEC_1.0.md
+++ b/formats/about/SPEC_1.0.md
@@ -1,0 +1,61 @@
+# About format
+
+<dl>
+	<dt>Namespace</dt><dd>`about`</dd>
+	<dt>Version</dt><dd>1.0</dd>
+</dl>
+
+This is an application format for describing personal information (e.g. display names, avatars, bios) associated with particular author keypairs.
+
+## Keypair association
+
+Personal information should only be publishable and modifiable by the holder of a specific keypair. 
+
+Therefore, each documents following this format is prefixed with the following:
+
+`/about/1.0/~{KEYPAIR_ADDRESS}`
+
+Where `KEYPAIR_ADDRESS` is the full public address of the keypair associated with this document, e.g. `@suzy.bo5sotcncvkr7p4c3lnexxpb4hjqi5tcxcov5b4irbnnz2teoifua`.
+
+The presence of an author keypair prefixed with a tilde in a path invokes path ownership, and only this keypair will be able to write to these paths.
+
+## Display names
+
+Author keypairs begin with a shortname to make the keypair easier to identify, e.g. `suzy`. These shortnames cannot be changed and are always four characters long. This makes them unsuitable for most names and the fluctuating nature of identity.
+
+Therefore it is desirable to have a free-form display name which can be changed at any time, and which can differ between each share.
+
+### Display name document path
+
+The path format of a display name document is:
+
+```
+`/about/1.0/~{KEYPAIR_ADDRESS}/displayName
+```
+
+### Display name document fields
+
+The `text` property of the document is the display name the keypair's owner wishes to use. It can be any UTF-8 string.
+
+## Avatars
+
+An image can be associated with an author keypair.
+
+### Avatar document path
+
+The path format of a display name document is:
+
+```
+`/about/1.0/~{KEYPAIR_ADDRESS}`/avatar.{IMAGE_EXTENSION}
+```
+
+where `IMAGE_EXTENSION` is either `gif`, `jpg`, or `png`, corresponding to the format of the data used with this document's attachment.
+
+### Avatar document fields
+
+- The `text` property of the document MUST be a textual description of the avatar image's contents, for use with screenreaders etc.
+- The attachment of the document MUST be an image file.
+	- The file size of the image MUST be less than or equal to 500,000 bytes.
+	- The dimensions of the image MUST NOT exceed 512 pixels on either side.
+	- The image SHOULD have a 1:1 aspect ratio.
+

--- a/formats/about/SPEC_1.0.md
+++ b/formats/about/SPEC_1.0.md
@@ -72,3 +72,21 @@ attachment data for this document.
     - The image SHOULD NOT be larger than 1,000,000 bytes. These images may be
       presented in interfaces where they are rendered alongside many other
       avatars, and which may impact the performance of rendering.
+
+## Status
+
+A short status message (e.g. "Away from keyboard") can optionally be associated
+with an author keypair.
+
+## Status document path
+
+The path format of a display name document is:
+
+```
+`/about/1.0/~{KEYPAIR_ADDRESS}`/status
+```
+
+## Status document fields
+
+The `text` property of the document is the status message the author wishes to
+associate with their keypair. It can be any UTF-8 string.

--- a/formats/server_settings/SPEC_1.0.md
+++ b/formats/server_settings/SPEC_1.0.md
@@ -5,8 +5,8 @@
 	<dt>Version</dt><dd>1.0</dd>
 </dl>
 
-This is a document application format for describing the configuration of an
-Earthstar server's hosted shares.
+This is an application format for describing the configuration of an Earthstar
+server's hosted shares.
 
 More settings may be added in future versions.
 


### PR DESCRIPTION
We've had these informally specified for a long time, and it's time to start making them formal.

This PR only specifies how display names and avatars should be formatted on an Earthstar share. Are there other critical fields which belong in the first version of this format? Perhaps it's worth specifying a way to have freeform fields on a profile, as is available on Mastodon profiles?

Ideas and collaboration welcome in this PR!